### PR TITLE
setting mathlink path correctly for linux with mathematica 10+

### DIFF
--- a/src/low_level.jl
+++ b/src/low_level.jl
@@ -12,7 +12,14 @@ include("consts.jl")
 typealias Env Ptr{Void}
 typealias Link Ptr{Void}
 
-mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : "ml64i3"
+verout = open("/tmp/checkversion.m","w")
+write(verout,"Print[\$VersionNumber]")
+close(verout)
+version=float(chomp(readall((`math -script /tmp/checkversion.m`)))
+
+mlib = "ml64i3"
+mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : mlib
+mlib = @unix ? (version>10 ? string("/usr/local/Wolfram/Mathematica/",version,"/SystemFiles/Links/MathLink/DeveloperKit/Linux-x86-64/CompilerAdditions/libML64i4") : mlib) : mlib 
 macro mlib(); mlib; end
 
 function Open(path = "math")

--- a/src/low_level.jl
+++ b/src/low_level.jl
@@ -12,16 +12,9 @@ include("consts.jl")
 typealias Env Ptr{Void}
 typealias Link Ptr{Void}
 
-<<<<<<< HEAD
 if isdir("/usr/local/Wolfram/Mathematica")
   version=readdir("/usr/local/Wolfram/Mathematica")[1]
 end
-=======
-verout = open("/tmp/checkversion.m","w")
-write(verout,"Print[\$VersionNumber]")
-close(verout)
-version=float(chomp(readall((`math -script /tmp/checkversion.m`))))
->>>>>>> eb91781d70ac075f07e24d4d2af11962fbd144a4
 
 mlib = "ml64i3"
 mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : mlib

--- a/src/low_level.jl
+++ b/src/low_level.jl
@@ -13,12 +13,12 @@ typealias Env Ptr{Void}
 typealias Link Ptr{Void}
 
 if isdir("/usr/local/Wolfram/Mathematica")
-  version=readdir("/usr/local/Wolfram/Mathematica")[1]
+  version=maximum(float(readdir("/usr/local/Wolfram/Mathematica")))
 end
 
 mlib = "ml64i3"
 mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : mlib
-mlib = @unix ? (float(version)>10 ? string("/usr/local/Wolfram/Mathematica/",version,"/SystemFiles/Links/MathLink/DeveloperKit/Linux-x86-64/CompilerAdditions/libML64i4") : mlib) : mlib 
+mlib = @unix ? (version>10 ? string("/usr/local/Wolfram/Mathematica/",version,"/SystemFiles/Links/MathLink/DeveloperKit/Linux-x86-64/CompilerAdditions/libML64i4") : mlib) : mlib 
 macro mlib(); mlib; end
 
 function Open(path = "math")

--- a/src/low_level.jl
+++ b/src/low_level.jl
@@ -12,14 +12,13 @@ include("consts.jl")
 typealias Env Ptr{Void}
 typealias Link Ptr{Void}
 
-verout = open("/tmp/checkversion.m","w")
-write(verout,"Print[\$VersionNumber]")
-close(verout)
-version=float(chomp(readall((`math -script /tmp/checkversion.m`)))
+if isdir("/usr/local/Wolfram/Mathematica")
+  version=readdir("/usr/local/Wolfram/Mathematica")[1]
+end
 
 mlib = "ml64i3"
 mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : mlib
-mlib = @unix ? (version>10 ? string("/usr/local/Wolfram/Mathematica/",version,"/SystemFiles/Links/MathLink/DeveloperKit/Linux-x86-64/CompilerAdditions/libML64i4") : mlib) : mlib 
+mlib = @unix ? (float(version)>10 ? string("/usr/local/Wolfram/Mathematica/",version,"/SystemFiles/Links/MathLink/DeveloperKit/Linux-x86-64/CompilerAdditions/libML64i4") : mlib) : mlib 
 macro mlib(); mlib; end
 
 function Open(path = "math")


### PR DESCRIPTION
The syntax for checking Mathematica's version number and current os is a bit cumbersome, but I think this is mostly Mathematica's/julia's fault.  I don't know where the mathlink library sits on linux with mathematica <10, so right now those cases will probably result in failure.  